### PR TITLE
Adding improv BLE support to the website.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,16 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.10.0
     hooks:
       - id: markdownlint-cli2
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+
+exclude: 'Gemfile.lock'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # esphome-econet.github.io
 
-This is a simple Github Pages Jekyll webiste, primarily used for installation of ESPHome-econet devices.
+This is a simple Github Pages Jekyll website, primarily used for installation of ESPHome-econet devices.
 
 To run the site locally, clone the repo and then run:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # esphome-econet.github.io
 
-esphome-econet.github.io
+This is a simple Github Pages Jekyll webiste, primarily used for installation of ESPHome-econet devices.
+
+To run the site locally, clone the repo and then run:
+
+```sh
+bundle install
+```
+
+to install all required Gems, followed by
+
+```sh
+bundle exec jekyll serve
+```
+
+to start the web server.

--- a/_includes/improvBLEButton.html
+++ b/_includes/improvBLEButton.html
@@ -1,0 +1,12 @@
+<head>
+    <script
+    type="module"
+    src="https://www.improv-wifi.com/sdk-js/launch-button.js">
+</script>
+</head>
+
+<p class="button-row" align="center">
+    <improv-wifi-launch-button>
+        <span slot='unsupported'>Your browser does not support provisioning.</span>
+    </improv-wifi-launch-button>
+</p>

--- a/_includes/improvSerialButton.html
+++ b/_includes/improvSerialButton.html
@@ -21,7 +21,6 @@
     ></script>
 </head>
 
-<p>Select your product</p>
 <ul class="radios">
   <li>
     <label><input type="radio" name="type" value="etwh" />Electric Tank Water Heater</label>

--- a/index.markdown
+++ b/index.markdown
@@ -7,4 +7,4 @@ title: ESPHome-econet
 ---
 To install ESPHome-econet on your device, [visit our installation page](/install).
 
-if you'd like help with your setup or to discuss potential improvements to ESPHome-econet, come join us on [our Discord](https://discord.gg/gytTnekGSz).
+If you'd like help with your setup or to discuss potential improvements to ESPHome-econet, come join us on [our Discord](https://discord.gg/gytTnekGSz).

--- a/install.markdown
+++ b/install.markdown
@@ -3,6 +3,13 @@ layout: page
 title: Installation
 permalink: /install/
 ---
-## Web-Based Installation
 
-{% include hardwareSelectorButton.html %}
+## Install ESPHome-Econet Using USB
+
+Select your appliance type from the list below, then click the button to install ESPHome-econet on the device over USB:
+{% include improvSerialButton.html %}
+
+## Configure ESP32 Device Wi-Fi Using Blueooth
+
+To configure Wi-Fi on an ESP32 device configured for Improv over BLE, click the button below while the device is powered on and in range:
+{% include improvBLEButton.html %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[codespell]
+check-filenames =


### PR DESCRIPTION
For clients with [improv BLE](https://esphome.io/components/esp32_improv) enabled, this enables them to be configured form the Installation page.